### PR TITLE
Check if an argument has been given for the application and exit

### DIFF
--- a/lookalikes.py
+++ b/lookalikes.py
@@ -157,4 +157,11 @@ def main(domain, limit=10):
             print '  %s %s' % (domain, rank)
 
 if __name__ == '__main__':
-    main(sys.argv[1])
+    if len(sys.argv) == 2:
+        main(sys.argv[1])
+    elif len(sys.argv) > 2:
+        print "Too many domain arguments given!"
+        exit(1)
+    else:
+        print "Required domain argument not given!"
+        exit(1)


### PR DESCRIPTION
Without any arguments, the program will just crash. 

A command-line option parser with multiple flag options would be cool. Then it could
just default to the help menu instead of crashing.

But, until I get around to that _**or forget about it**_: a simple warning to
let the user know what went wrong and a proper exit code should suffice?